### PR TITLE
[Feature] Add a flag to disable the automatic expand toggle

### DIFF
--- a/lib/src/expandable_card.dart
+++ b/lib/src/expandable_card.dart
@@ -50,7 +50,7 @@ class ExpandableCard extends StatefulWidget {
     super.key,
     this.id,
     this.animationDuration,
-    this.manualExpandToggle = false,
+    this.expandOnTap = true,
   })  : assert(
           detailsBuilder == null || !initiallyExpanded,
           'Cannot start expanded if detailsBuilder is not null',
@@ -135,10 +135,10 @@ class ExpandableCard extends StatefulWidget {
   final bool initiallyExpanded;
 
   /// If this flag is true the [_onHandleTap] method will
-  /// not be called automatically when tapping on the child.
-  /// Tapping on the child will not automatically toggle
+  /// be called automatically when tapping on the child.
+  /// Tapping on the child will automatically toggle
   /// the expand state of the widget.
-  final bool manualExpandToggle;
+  final bool expandOnTap;
 
   @override
   State<ExpandableCard> createState() => _ExpandableCardState();
@@ -385,7 +385,7 @@ class _ExpandableCardState extends State<ExpandableCard>
         surfaceTintColor: theme.colorScheme.surfaceTint,
         shape: _cardShape?.value ?? shapeCollapsed,
         child: InkWell(
-          onTap: widget.detailsBuilder != null && !widget.manualExpandToggle
+          onTap: widget.detailsBuilder != null && widget.expandOnTap
               ? _handleTap
               : null,
           child: Padding(

--- a/lib/src/expandable_card.dart
+++ b/lib/src/expandable_card.dart
@@ -50,6 +50,7 @@ class ExpandableCard extends StatefulWidget {
     super.key,
     this.id,
     this.animationDuration,
+    this.manualExpandToggle = false,
   })  : assert(
           detailsBuilder == null || !initiallyExpanded,
           'Cannot start expanded if detailsBuilder is not null',
@@ -132,6 +133,12 @@ class ExpandableCard extends StatefulWidget {
 
   /// If this card should start expanded
   final bool initiallyExpanded;
+
+  /// If this flag is true the [_onHandleTap] method will
+  /// not be called automatically when tapping on the child.
+  /// Tapping on the child will not automatically toggle
+  /// the expand state of the widget.
+  final bool manualExpandToggle;
 
   @override
   State<ExpandableCard> createState() => _ExpandableCardState();
@@ -378,7 +385,9 @@ class _ExpandableCardState extends State<ExpandableCard>
         surfaceTintColor: theme.colorScheme.surfaceTint,
         shape: _cardShape?.value ?? shapeCollapsed,
         child: InkWell(
-          onTap: widget.detailsBuilder != null ? _handleTap : null,
+          onTap: widget.detailsBuilder != null && !widget.manualExpandToggle
+              ? _handleTap
+              : null,
           child: Padding(
             padding: _cardPadding?.value ?? paddingCollapsed!,
             child: Column(


### PR DESCRIPTION
[Feature] Add a flag to disable the automatic expand toggle

* In advance use-cases of this lib, the automatic expand toggle function is not desired. A new flag - manualExpandToggle was added which if set to true the onTap listener on the ExpandableCard child InkWell will be set to null.